### PR TITLE
Scope Pages workflow concurrency by ref

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,7 +15,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- scope the Pages workflow concurrency group by `github.ref` instead of using one shared `pages` group
- prevent pull request workflow runs from cancelling an in-flight deploy from a push to `main`
- keep cancel-in-progress behavior for repeated runs on the same branch or ref

## Verification
- bundle exec jekyll build
- yq parsed `.github/workflows/pages.yml`
- confirmed `.concurrency.group` contains `github.ref`
- git diff --check origin/main..HEAD