### PR TITLE
Add repository-local Renovate automation

### DIFF
--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -1,0 +1,64 @@
+name: Renovate PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      github.event.pull_request.user.login == 'renovate-bot' ||
+      github.event.pull_request.user.login == format('{0}[bot]', vars.RENOVATE_APP_SLUG)
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Review PR and post comment
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          gh pr view "$PR_NUMBER" --repo "$REPO" --json title,body > /tmp/pr.json
+          PR_TITLE="$(jq -r '.title' /tmp/pr.json)"
+
+          {
+            echo "You are reviewing a Renovate dependency update PR in this repository."
+            echo
+            echo "PR Title: $PR_TITLE"
+            echo
+            echo "PR Body (includes Renovate's changelog/release notes summary):"
+            jq -r '.body' /tmp/pr.json
+            echo
+            echo "Review the dependency update and check for:"
+            echo "1. Breaking changes that require code changes in this repo"
+            echo "2. Major version bumps that need migration work"
+            echo "3. Compatibility issues with the Jekyll site build and GitHub Actions workflows"
+            echo
+            echo "Use the local repository contents to inspect how the dependency is used."
+            echo
+            echo "Format your response as a PR comment. Start with one of:"
+            echo "- '## Renovate Review: Mergeable'"
+            echo "- '## Renovate Review: Needs Review'"
+          } > /tmp/prompt.txt
+
+          REVIEW="$(claude -p \
+            --model claude-opus-4-6 \
+            --allowedTools 'Read,Grep,Glob' \
+            --max-turns 10 \
+            --output-format json < /tmp/prompt.txt | jq -r '.result')"
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$REVIEW"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,36 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 3 * * *'
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v2.2.2
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Checkout
+        uses: actions/checkout@v6.0.1
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v44.0.3
+        with:
+          token: ${{ steps.app_token.outputs.token }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@
 **Deployment**
 
 The site is deployed by the GitHub Actions Pages workflow in `.github/workflows/pages.yml`.
+
+## Renovate setup
+
+This repository expects these GitHub repository settings for Renovate:
+
+- secret `RENOVATE_APP_ID`
+- secret `RENOVATE_APP_PRIVATE_KEY`
+- variable `RENOVATE_APP_SLUG`
+- secret `CLAUDE_CODE_OAUTH_TOKEN`

--- a/docs/superpowers/specs/2026-04-19-renovate-github-app-design.md
+++ b/docs/superpowers/specs/2026-04-19-renovate-github-app-design.md
@@ -1,0 +1,225 @@
+# Renovate GitHub App Design
+
+Date: 2026-04-19
+Status: Approved for planning
+
+## Summary
+
+Add Renovate to this Jekyll blog repository using the same repository-owned GitHub Actions pattern as `new-machine-bootstrap`. The repo will gain a committed `renovate.json`, a scheduled Renovate runner workflow authenticated with a repo-scoped GitHub App, and a companion PR review workflow that comments on Renovate pull requests.
+
+The configuration baseline should match the approved "B" option:
+
+- `extends: ["config:recommended"]`
+- `minimumReleaseAge: "7 days"`
+- `labels: ["dependencies"]`
+
+This work is intentionally narrow. It enables Renovate for the dependency types already present in this repo, keeps policy light, and avoids introducing broader dependency-management automation such as auto-merge or custom grouping.
+
+## Current State
+
+This repository is a small Jekyll site with:
+
+- Ruby dependencies managed through `Gemfile` and `Gemfile.lock`
+- GitHub Actions workflows under `.github/workflows/`
+- a GitHub Pages deployment workflow in `.github/workflows/pages.yml`
+
+It does not currently have:
+
+- a root `renovate.json`
+- any Renovate workflow
+- any Dependabot configuration
+- a Renovate PR review workflow
+
+That means dependency updates for gems and GitHub Actions versions are currently manual.
+
+## Goals
+
+- Enable automated dependency update PRs for this repository
+- Match the proven GitHub Actions and GitHub App pattern already used in `new-machine-bootstrap`
+- Keep Renovate policy minimal and predictable
+- Ensure Renovate-authored PRs trigger an AI review comment workflow
+- Avoid changing the existing Pages deployment design
+
+## Non-Goals
+
+- Do not add auto-merge
+- Do not add custom regex managers
+- Do not add grouping or rate-limiting rules beyond the recommended baseline
+- Do not move Renovate execution into another repository
+- Do not change site code, content, or the Pages workflow behavior outside of dependency updates
+
+## Chosen Approach
+
+Three approaches were considered:
+
+- Repository-local Renovate with parity baseline
+- Repository-local Renovate with a minimal config
+- Repository-local Renovate with extra grouping and PR-volume controls
+
+The chosen approach is repository-local Renovate with parity baseline.
+
+Why this approach:
+
+- It matches the user's reference implementation in `new-machine-bootstrap`
+- It is simple enough for this small repo
+- It avoids drift between repositories without copying unnecessary custom manager logic
+- It keeps future maintenance obvious: the committed config is the source of truth
+
+## Architecture
+
+Add three repository-owned pieces:
+
+### 1. Root Renovate config
+
+Create `renovate.json` at the repository root with:
+
+- `"$schema": "https://docs.renovatebot.com/renovate-schema.json"`
+- `extends: ["config:recommended"]`
+- `minimumReleaseAge: "7 days"`
+- `labels: ["dependencies"]`
+
+No custom managers should be added in this repo unless a future dependency source cannot be covered by Renovate's built-in managers.
+
+### 2. Renovate runner workflow
+
+Create `.github/workflows/renovate.yml`.
+
+This workflow should:
+
+- run on a daily schedule
+- support `workflow_dispatch`
+- mint a short-lived installation token with `actions/create-github-app-token`
+- check out the repository
+- run `renovatebot/github-action`
+- target only `${{ github.repository }}`
+
+Use the same schedule shape as the reference repo:
+
+```yaml
+schedule:
+  - cron: '23 3 * * *'
+```
+
+The workflow should use the GitHub App token for Renovate itself, not `GITHUB_TOKEN`.
+
+### 3. Renovate PR review workflow
+
+Create `.github/workflows/renovate-review.yml`.
+
+This workflow should:
+
+- trigger on pull request `opened`, `synchronize`, and `reopened`
+- run only for Renovate-authored PRs
+- install the Claude Code CLI
+- inspect the PR title and body
+- post a review comment back to the PR
+
+The PR author gate must allow these exact identities:
+
+- `renovate[bot]`
+- `renovate-bot`
+- `format('{0}[bot]', vars.RENOVATE_APP_SLUG)`
+
+That keeps compatibility with hosted Renovate bot names while also supporting the repository's dedicated GitHub App bot identity.
+
+## Authentication And Repository Settings
+
+The Renovate runner should authenticate with a GitHub App installed only on this repository.
+
+Required repository secrets:
+
+- `RENOVATE_APP_ID`
+- `RENOVATE_APP_PRIVATE_KEY`
+
+Required repository variables:
+
+- `RENOVATE_APP_SLUG`
+
+Required additional review secret:
+
+- `CLAUDE_CODE_OAUTH_TOKEN`
+
+Why this design:
+
+- the GitHub App token has the permissions Renovate needs
+- the token is short-lived and minted at runtime
+- PRs created with the App token can trigger downstream workflows correctly
+- the bot login is stable enough to gate the review workflow exactly
+
+The GitHub App should be installed only on `f1sherman/f1sherman.github.io`, not account-wide.
+
+Required GitHub App permissions:
+
+- Checks: read and write
+- Commit statuses: read and write
+- Contents: read and write
+- Issues: read and write
+- Pull requests: read and write
+- Workflows: read and write
+- Administration: read
+- Dependabot alerts: read
+- Members: read
+- Metadata: read
+
+The review workflow may still use the repository-provided `GITHUB_TOKEN` for reading PR metadata and posting its comment. The restriction in this design is only that Renovate itself must authenticate with the GitHub App token.
+
+## Dependency Coverage
+
+Initial dependency coverage should be only what Renovate already understands from this repository structure:
+
+- Bundler dependencies from `Gemfile` and `Gemfile.lock`
+- GitHub Actions versions in `.github/workflows/*.yml`
+
+No custom extraction logic is needed for this repo at initial rollout.
+
+## Data Flow
+
+1. A scheduled run or manual dispatch starts `.github/workflows/renovate.yml`.
+2. The workflow mints a short-lived GitHub App installation token.
+3. Renovate reads the committed `renovate.json`.
+4. Renovate scans the repository for supported managers.
+5. Renovate opens or updates dependency PRs as the App bot.
+6. A Renovate PR event triggers `.github/workflows/renovate-review.yml`.
+7. The review workflow posts an AI-generated dependency review comment.
+
+## Error Handling
+
+- Missing or invalid Renovate App secrets should fail the runner workflow in the token step.
+- A wrong `RENOVATE_APP_SLUG` value should not block Renovate itself, but it will prevent the review workflow from running on App-authored PRs.
+- A missing `CLAUDE_CODE_OAUTH_TOKEN` should fail only the review workflow; the dependency PR remains usable.
+- `GITHUB_TOKEN` should not be used as the Renovate run token, because that can suppress expected follow-on workflow behavior on Renovate PRs.
+
+## Verification
+
+Implementation is not complete until both local static checks and a GitHub-side smoke test pass.
+
+Minimum local verification:
+
+- validate the committed `renovate.json`
+- validate that `.github/workflows/renovate.yml` contains the daily schedule, `workflow_dispatch`, GitHub App token minting, and `renovatebot/github-action`
+- validate that `.github/workflows/renovate-review.yml` contains the exact Renovate bot gate including `vars.RENOVATE_APP_SLUG`
+
+Post-configuration smoke test:
+
+- set the required repository secrets and variable
+- manually dispatch `renovate.yml`
+- confirm the workflow run succeeds
+- confirm Renovate opens or updates PRs if updates are available
+- confirm a Renovate PR triggers the review workflow
+
+## Expected Files To Change During Implementation
+
+- `renovate.json`
+- `.github/workflows/renovate.yml`
+- `.github/workflows/renovate-review.yml`
+- `README.md` if setup or verification notes need to be documented there
+
+## Out Of Scope Follow-Up Work
+
+Reasonable future additions, but not part of this design:
+
+- auto-merge for selected update classes
+- package grouping rules
+- PR-rate limiting rules
+- custom managers for non-standard pinned versions
+- caching or other GitHub Actions runtime optimizations

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
+  "labels": ["dependencies"]
+}

--- a/tests/renovate-config.sh
+++ b/tests/renovate-config.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+require_file() {
+  local path="$1"
+  [[ -f "$path" ]] || {
+    echo "missing file: $path" >&2
+    exit 1
+  }
+}
+
+require_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  [[ "$actual" == "$expected" ]] || {
+    echo "$message: expected '$expected', got '$actual'" >&2
+    exit 1
+  }
+}
+
+require_file "renovate.json"
+require_file ".github/workflows/renovate.yml"
+require_file ".github/workflows/renovate-review.yml"
+
+schema="$(jq -r '."$schema"' renovate.json)"
+extends0="$(jq -r '.extends[0]' renovate.json)"
+min_age="$(jq -r '.minimumReleaseAge' renovate.json)"
+label0="$(jq -r '.labels[0]' renovate.json)"
+
+require_eq "$schema" "https://docs.renovatebot.com/renovate-schema.json" "schema mismatch"
+require_eq "$extends0" "config:recommended" "extends mismatch"
+require_eq "$min_age" "7 days" "minimumReleaseAge mismatch"
+require_eq "$label0" "dependencies" "label mismatch"
+
+schedule0="$(yq -r '.on.schedule[0].cron' .github/workflows/renovate.yml)"
+dispatch_count="$(yq -r '.on.workflow_dispatch | length' .github/workflows/renovate.yml)"
+token_uses="$(yq -r '.jobs.renovate.steps[] | select(.id == "app_token") | .uses' .github/workflows/renovate.yml)"
+checkout_uses="$(yq -r '.jobs.renovate.steps[] | select(.name == "Checkout") | .uses' .github/workflows/renovate.yml)"
+renovate_uses="$(yq -r '.jobs.renovate.steps[] | select(.name == "Self-hosted Renovate") | .uses' .github/workflows/renovate.yml)"
+token_expr="$(yq -r '.jobs.renovate.steps[] | select(.name == "Self-hosted Renovate") | .with.token' .github/workflows/renovate.yml)"
+repo_expr="$(yq -r '.jobs.renovate.steps[] | select(.name == "Self-hosted Renovate") | .env.RENOVATE_REPOSITORIES' .github/workflows/renovate.yml)"
+
+require_eq "$schedule0" "23 3 * * *" "Renovate schedule mismatch"
+require_eq "$dispatch_count" "0" "workflow_dispatch should be an empty mapping"
+require_eq "$token_uses" "actions/create-github-app-token@v2.2.2" "GitHub App token action mismatch"
+require_eq "$checkout_uses" "actions/checkout@v6.0.1" "checkout action mismatch"
+require_eq "$renovate_uses" "renovatebot/github-action@v44.0.3" "Renovate action mismatch"
+require_eq "$token_expr" '${{ steps.app_token.outputs.token }}' "Renovate token mismatch"
+require_eq "$repo_expr" '${{ github.repository }}' "RENOVATE_REPOSITORIES mismatch"
+
+review_types="$(yq -r '.on.pull_request.types | join(",")' .github/workflows/renovate-review.yml)"
+review_if="$(yq -r '.jobs.review.if' .github/workflows/renovate-review.yml)"
+
+require_eq "$review_types" "opened,synchronize,reopened" "Review trigger mismatch"
+require_eq "$review_if" "github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'renovate-bot' || github.event.pull_request.user.login == format('{0}[bot]', vars.RENOVATE_APP_SLUG)" "Review gate mismatch"


### PR DESCRIPTION
## Summary
- add a root renovate.json with the same baseline knobs used in new-machine-bootstrap
- add a scheduled GitHub App-backed Renovate workflow for this repo
- add a Renovate PR review workflow plus a local shell verification script and setup note

## Verification
- bash tests/renovate-config.sh
- mise exec ruby@3.4.4 -- bundle _2.3.17_ exec jekyll build